### PR TITLE
Add SDF to PDB conversion endpoint

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 
 # Virtual Environment
 venv/
+.venv/
+.pytest_cache/
 .env
 
 # Docker


### PR DESCRIPTION
## Summary
- add `.venv` and `.pytest_cache` to ignored files
- implement `/prompt/sdf-to-pdb/` endpoint to convert SDF text to a PDB block using RDKit

## Testing
- `PYTHONPATH=. ./.venv/bin/pytest api/routers/prompt/test_routes.py::test_submit_prompt -q` *(fails: OpenAI API key is required)*