### PR TITLE
Document RCSB agent progress and stabilize tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,4 +70,12 @@ The ability to deliver immersive molecular experiences differentiates the platfo
 
 Conclusion
 
-The Moleculens server already leverages PyMOL and RDKit to render molecular images, but it lacks integration with modern RCSB tools and does not support interactive or XR‑ready outputs.  Recent improvements to RCSB’s Mol* viewer—improved rendering, glTF export and user‑upload functionality ￼ ￼—provide an opportunity to build a powerful on‑demand graphics service.  By systematically adding data retrieval layers, modular rendering templates, Mol* integration and XR/VR export capabilities, the platform can evolve into a full‑fledged molecular visualization pipeline.  The most lucrative path involves investing in XR/VR outputs via glTF and USDZ export, enabling immersive experiences for education, research and corporate clients.
+The Moleculens server already leverages PyMOL and RDKit to render molecular images, but it lacks integration with modern RCSB tools and does not support interactive or XR‑ready outputs.  Recent improvements to RCSB’s Mol* viewer—improved rendering, glTF export and user‑upload functionality—provide an opportunity to build a powerful on‑demand graphics service.  By systematically adding data retrieval layers, modular rendering templates, Mol* integration and XR/VR export capabilities, the platform can evolve into a full‑fledged molecular visualization pipeline.  The most lucrative path involves investing in XR/VR outputs via glTF and USDZ export, enabling immersive experiences for education, research and corporate clients.
+
+### July 2025 Progress: Initial RCSB Integration
+
+* Implemented a simple `RCSBAgent` that downloads PDB or mmCIF files from the RCSB repository.
+* Added a `/rcsb/fetch-structure/` endpoint returning the raw structure data.
+* Registered this agent in `AgentFactory` and extended `AgentType` with a `RCSB` option.
+* Created tests that stub heavy dependencies (RDKit, OpenAI) and validate both geometry and RCSB routes.
+* Pinned `httpx` to a compatible version so Starlette's `TestClient` works correctly during testing.

--- a/tests/test_geometry_endpoints.py
+++ b/tests/test_geometry_endpoints.py
@@ -10,6 +10,22 @@ rdkit_mod = types.ModuleType('rdkit')
 rdkit_mod.Chem = chem_mod
 sys.modules['rdkit'] = rdkit_mod
 sys.modules['rdkit.Chem'] = chem_mod
+
+# Stub out the heavy `openai` dependency used in some modules
+openai_mod = types.ModuleType('openai')
+openai_mod.OpenAI = object
+types_mod = types.ModuleType('openai.types')
+chat_mod = types.ModuleType('openai.types.chat')
+chat_completion_mod = types.ModuleType('openai.types.chat.chat_completion')
+setattr(types_mod, 'Completion', object)
+setattr(chat_mod, 'ChatCompletion', object)
+setattr(chat_mod, 'ChatCompletionMessage', object)
+setattr(chat_mod, 'ChatCompletionMessageParam', dict)
+setattr(chat_completion_mod, 'Choice', object)
+sys.modules['openai'] = openai_mod
+sys.modules['openai.types'] = types_mod
+sys.modules['openai.types.chat'] = chat_mod
+sys.modules['openai.types.chat.chat_completion'] = chat_completion_mod
 from api.main import app
 
 client = TestClient(app)

--- a/tests/test_rcsb_endpoints.py
+++ b/tests/test_rcsb_endpoints.py
@@ -10,6 +10,22 @@ rdkit_mod = types.ModuleType('rdkit')
 rdkit_mod.Chem = chem_mod
 sys.modules['rdkit'] = rdkit_mod
 sys.modules['rdkit.Chem'] = chem_mod
+
+# Stub out the heavy `openai` dependency used in some modules
+openai_mod = types.ModuleType('openai')
+openai_mod.OpenAI = object
+types_mod = types.ModuleType('openai.types')
+chat_mod = types.ModuleType('openai.types.chat')
+chat_completion_mod = types.ModuleType('openai.types.chat.chat_completion')
+setattr(types_mod, 'Completion', object)
+setattr(chat_mod, 'ChatCompletion', object)
+setattr(chat_mod, 'ChatCompletionMessage', object)
+setattr(chat_mod, 'ChatCompletionMessageParam', dict)
+setattr(chat_completion_mod, 'Choice', object)
+sys.modules['openai'] = openai_mod
+sys.modules['openai.types'] = types_mod
+sys.modules['openai.types.chat'] = chat_mod
+sys.modules['openai.types.chat.chat_completion'] = chat_completion_mod
 from api.main import app
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
- stub `openai` package in unit tests
- ensure geometry and RCSB endpoints work under test
- pin `httpx` so `TestClient` works
- log latest progress in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e12805708321b6414d87783aa7e2