### PR TITLE
Add AlphaFold and metadata support to RCSB agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,3 +79,17 @@ The Moleculens server already leverages PyMOL and RDKit to render molecular imag
 * Registered this agent in `AgentFactory` and extended `AgentType` with a `RCSB` option.
 * Created tests that stub heavy dependencies (RDKit, OpenAI) and validate both geometry and RCSB routes.
 * Pinned `httpx` to a compatible version so Starlette's `TestClient` works correctly during testing.
+
+## RCSB Agent expansion (July 18 2025)
+
+Following the initial integration of the RCSB agent, the back‑end now exposes additional capabilities to support computed structure models and metadata retrieval:
+
+* Added `fetch_alphafold_model` and `fetch_entry_metadata` methods to `RCSBAgent`.  These allow downloading predicted structures from the AlphaFold database (using UniProt accessions) and retrieving JSON metadata for PDB entries via the RCSB Data API.  A common `_check_format` helper normalizes the PDB/mmCIF format argument.
+* Extended `api/routers/rcsb/routes.py` with two new endpoints:
+  * `POST /rcsb/fetch-model/` accepts a UniProt ID and format (pdb or cif) and returns a predicted model downloaded from the AlphaFold DB.
+  * `GET /rcsb/entry/{identifier}` returns metadata for a PDB entry by delegating to the Data API.
+* Added a default `AgentModelConfig` for the `rcsb` agent type to `agent_model_config.py` to ensure consistent registration in the factory.
+* Added `tests/test_rcsb_extensions.py` which stubs external dependencies and verifies the new endpoints.  These tests follow the pattern used for geometry and RCSB structure tests by injecting fake modules and patching agent methods to avoid network calls.
+* The original `fetch_structure` endpoint and tests continue to function unchanged.
+
+This update progresses the data retrieval layer outlined in the expansion plan and lays groundwork for subsequent features like sequence annotations, alignments and user uploads.

--- a/api/agent_management/agent_model_config.py
+++ b/api/agent_management/agent_model_config.py
@@ -97,6 +97,13 @@ DEFAULT_AGENT_MODELS = [
         fallback_models=["gpt-4o", "claude-3-7-sonnet-latest", "gpt-4.5-preview"],
         required_categories=[ModelCategory.REASONING],
         description="Handles PubChem data retrieval and processing"
+    ),
+    AgentModelConfig(
+        agent_type=AgentType.RCSB,
+        preferred_model="o3-mini",
+        fallback_models=[],
+        required_categories=[],
+        description="Fetches structures, predicted models and metadata from RCSB and AlphaFold"
     )
 ]
 

--- a/api/agent_management/agents/rcsb_agent.py
+++ b/api/agent_management/agents/rcsb_agent.py
@@ -1,9 +1,17 @@
 import requests
 
 class RCSBAgent:
-    """Simple agent to retrieve structure files from the RCSB PDB."""
+    """Retrieve experimental and computed structures plus metadata from RCSB and AlphaFold."""
 
     BASE_URL = "https://files.rcsb.org/download/"
+    AF_BASE_URL = "https://alphafold.ebi.ac.uk/files/"
+    DATA_API_URL = "https://data.rcsb.org/rest/v1/core/"
+
+    def _check_format(self, fmt: str) -> str:
+        fmt = fmt.lower()
+        if fmt not in {"pdb", "cif"}:
+            raise ValueError("format must be 'pdb' or 'cif'")
+        return fmt
 
     def fetch_structure(self, identifier: str, file_format: str = "pdb") -> str:
         """Download a structure file from RCSB.
@@ -18,10 +26,32 @@ class RCSBAgent:
         str
             File contents as a string.
         """
-        fmt = file_format.lower()
-        if fmt not in {"pdb", "cif"}:
-            raise ValueError("format must be 'pdb' or 'cif'")
+        fmt = self._check_format(file_format)
         url = f"{self.BASE_URL}{identifier.upper()}.{ 'cif' if fmt == 'cif' else 'pdb' }"
         resp = requests.get(url, timeout=30)
         resp.raise_for_status()
         return resp.text
+
+    def fetch_alphafold_model(self, uniprot_id: str, file_format: str = "pdb") -> str:
+        """
+        Retrieve a predicted structure from AlphaFold DB.
+        uniprot_id: UniProt accession, e.g. P68871.
+        file_format: 'pdb' or 'cif'.
+        Returns the contents of the model file.
+        """
+        fmt = self._check_format(file_format)
+        suffix = "model_v4.cif" if fmt == "cif" else "model_v4.pdb"
+        filename = f"AF-{uniprot_id}-F1-{suffix}"
+        resp = requests.get(f"{self.AF_BASE_URL}{filename}", timeout=30)
+        resp.raise_for_status()
+        return resp.text
+
+    def fetch_entry_metadata(self, identifier: str) -> dict:
+        """
+        Retrieve JSON metadata for an entry via the RCSB Data API.
+        identifier: PDB ID.
+        Returns a dict with metadata.
+        """
+        resp = requests.get(f"{self.DATA_API_URL}entry/{identifier}", timeout=30)
+        resp.raise_for_status()
+        return resp.json()

--- a/api/routers/rcsb/routes.py
+++ b/api/routers/rcsb/routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from typing import Literal
+from typing import Literal, Dict, Any
 from agent_management.agents.rcsb_agent import RCSBAgent
 
 router = APIRouter(
@@ -16,11 +16,36 @@ class StructureRequest(BaseModel):
 class StructureResponse(BaseModel):
     data: str
 
+class ModelRequest(BaseModel):
+    uniprot_id: str
+    format: Literal["pdb", "cif"] = "pdb"
+
+class MetadataResponse(BaseModel):
+    metadata: Dict[str, Any]
+
 @router.post("/fetch-structure/", response_model=StructureResponse)
 def fetch_structure(request: StructureRequest) -> StructureResponse:
     try:
         agent = RCSBAgent()
         content = agent.fetch_structure(request.identifier, request.format)
         return StructureResponse(data=content)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/fetch-model/", response_model=StructureResponse)
+def fetch_model(request: ModelRequest) -> StructureResponse:
+    try:
+        agent = RCSBAgent()
+        content = agent.fetch_alphafold_model(request.uniprot_id, request.format)
+        return StructureResponse(data=content)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/entry/{identifier}", response_model=MetadataResponse)
+def entry_metadata(identifier: str) -> MetadataResponse:
+    try:
+        agent = RCSBAgent()
+        meta = agent.fetch_entry_metadata(identifier)
+        return MetadataResponse(metadata=meta)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_rcsb_extensions.py
+++ b/tests/test_rcsb_extensions.py
@@ -1,0 +1,49 @@
+from fastapi.testclient import TestClient
+import sys, os, types
+
+# stub rdkit to avoid heavy imports
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+chem_mod = types.ModuleType('rdkit.Chem')
+chem_mod.Fragments = object
+chem_mod.Descriptors = object
+chem_mod.AllChem = object
+rdkit_mod = types.ModuleType('rdkit')
+rdkit_mod.Chem = chem_mod
+sys.modules['rdkit'] = rdkit_mod
+sys.modules['rdkit.Chem'] = chem_mod
+
+from api.main import app
+from agent_management.agents.rcsb_agent import RCSBAgent
+
+client = TestClient(app)
+
+
+def test_fetch_model_endpoint():
+    # stub the agent method to avoid network
+    original = RCSBAgent.fetch_alphafold_model
+    def fake(self, uniprot_id: str, file_format: str = "pdb") -> str:
+        assert uniprot_id == "P12345"
+        assert file_format == "pdb"
+        return "MODEL_DATA"
+    RCSBAgent.fetch_alphafold_model = fake
+    try:
+        resp = client.post("/rcsb/fetch-model/", json={"uniprot_id": "P12345", "format": "pdb"})
+        assert resp.status_code == 200
+        assert resp.json()["data"] == "MODEL_DATA"
+    finally:
+        RCSBAgent.fetch_alphafold_model = original
+
+
+def test_entry_metadata_endpoint():
+    # stub the agent method to avoid network
+    original = RCSBAgent.fetch_entry_metadata
+    def fake_meta(self, identifier: str) -> dict:
+        assert identifier == "1ABC"
+        return {"rcsb_id": identifier}
+    RCSBAgent.fetch_entry_metadata = fake_meta
+    try:
+        resp = client.get("/rcsb/entry/1ABC")
+        assert resp.status_code == 200
+        assert resp.json()["metadata"]["rcsb_id"] == "1ABC"
+    finally:
+        RCSBAgent.fetch_entry_metadata = original


### PR DESCRIPTION
## Summary
- expand `RCSBAgent` with AlphaFold and metadata helpers
- expose new `/rcsb/fetch-model/` and `/rcsb/entry/{id}` endpoints
- register default model for RCSB agent
- add tests covering new endpoints
- update project log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e67922608321861902001c672217