### PR TITLE
Implement RCSB alignment and group endpoints

### DIFF
--- a/api/agent_management/agents/rcsb_agent.py
+++ b/api/agent_management/agents/rcsb_agent.py
@@ -11,6 +11,7 @@ class RCSBAgent:
     GRAPHQL_URL = "https://data.rcsb.org/graphql"
     ESM_BASE_URL = "https://esmatlas.com/api/v1/prediction/"
     UPLOAD_URL = "https://www.rcsb.org/api/v1/molstar/upload"
+    ALIGN_URL = "https://www.rcsb.org/api/v1/align"
 
     def _check_format(self, fmt: str) -> str:
         fmt = fmt.lower()
@@ -102,3 +103,24 @@ class RCSBAgent:
         resp.raise_for_status()
         data = resp.json()
         return data.get("id") or data.get("url")
+
+    def fetch_pairwise_alignment(self, id_one: str, id_two: str) -> dict:
+        """Align two structures or accessions using the RCSB alignment API."""
+        payload = {"id1": id_one, "id2": id_two}
+        resp = requests.post(self.ALIGN_URL, json=payload, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+    def fetch_group_entries(self, group_id: str) -> dict:
+        """Retrieve entries that belong to a specific RCSB group."""
+        url = f"{self.DATA_API_URL}group/{group_id}"
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+    def fetch_feature_annotations(self, identifier: str) -> dict:
+        """Get domain and motif annotations for a structure or accession."""
+        url = f"{self.DATA_API_URL}feature/{identifier}"
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp.json()

--- a/api/routers/rcsb/routes.py
+++ b/api/routers/rcsb/routes.py
@@ -47,6 +47,11 @@ class UploadResponse(BaseModel):
     upload_id: str
 
 
+class AlignmentRequest(BaseModel):
+    identifier1: str
+    identifier2: str
+
+
 @router.post("/fetch-structure/", response_model=StructureResponse)
 def fetch_structure(request: StructureRequest) -> StructureResponse:
     try:
@@ -113,5 +118,35 @@ def upload_structure(request: UploadRequest) -> UploadResponse:
         agent = RCSBAgent()
         upload_id = agent.upload_structure(request.data.encode(), request.filename)
         return UploadResponse(upload_id=upload_id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/align/", response_model=MetadataResponse)
+def pairwise_alignment(request: AlignmentRequest) -> MetadataResponse:
+    try:
+        agent = RCSBAgent()
+        data = agent.fetch_pairwise_alignment(request.identifier1, request.identifier2)
+        return MetadataResponse(metadata=data)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/group/{group_id}", response_model=MetadataResponse)
+def group_entries(group_id: str) -> MetadataResponse:
+    try:
+        agent = RCSBAgent()
+        data = agent.fetch_group_entries(group_id)
+        return MetadataResponse(metadata=data)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/feature-annotations/{identifier}", response_model=AnnotationResponse)
+def feature_annotations(identifier: str) -> AnnotationResponse:
+    try:
+        agent = RCSBAgent()
+        data = agent.fetch_feature_annotations(identifier)
+        return AnnotationResponse(annotations=data)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -3,14 +3,149 @@
 import os
 import sys
 import types
-from typing import Any, Dict, Generator
+from typing import Any, Dict, Generator, Generic, Optional, Type, TypeVar
+from enum import Enum
+
+from pydantic import BaseModel
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+import importlib.util
+from pathlib import Path
+
+# Load the RCSB agent module directly and expose it under the expected package path
+_agent_path = Path(__file__).resolve().parents[1] / "agent_management" / "agents" / "rcsb_agent.py"
+spec_agent = importlib.util.spec_from_file_location("agent_management.agents.rcsb_agent", _agent_path)
+rcsb_agent_mod = importlib.util.module_from_spec(spec_agent)
+assert spec_agent and spec_agent.loader
+spec_agent.loader.exec_module(rcsb_agent_mod)
+
+# Minimal model_config stub required by models and llm_service
+model_config_stub = types.ModuleType("api.agent_management.model_config")
+class _ProviderType(str, Enum):
+    OPENAI = "openai"
+
+class _LLMModelConfig(BaseModel):  # type: ignore[misc]
+    provider: _ProviderType
+    model_name: str
+
+model_config_stub.ProviderType = _ProviderType
+model_config_stub.LLMModelConfig = _LLMModelConfig
+sys.modules["api.agent_management.model_config"] = model_config_stub
+
+agent_pkg = types.ModuleType("agent_management.agents")
+agent_pkg.rcsb_agent = rcsb_agent_mod
+agent_root = types.ModuleType("agent_management")
+agent_root.agents = agent_pkg
+sys.modules["agent_management"] = agent_root
+sys.modules["agent_management.agents"] = agent_pkg
+sys.modules["agent_management.agents.rcsb_agent"] = rcsb_agent_mod
+api_mod = types.ModuleType("api")
+api_mod.agent_management = agent_root
+sys.modules["api"] = api_mod
+sys.modules["api.agent_management"] = agent_root
+sys.modules["api.agent_management.agents"] = agent_pkg
+sys.modules["api.agent_management.agents.rcsb_agent"] = rcsb_agent_mod
+
+# Provide lightweight stubs for models and the LLM service used in unit tests
+models_stub = types.ModuleType("agent_management.models")
+
+class LLMResponse(BaseModel):
+    content: str = ""
+    model: str = ""
+    usage: Dict[str, int] = {}
+
+
+T = TypeVar("T")
+
+class StructuredLLMRequest(BaseModel, Generic[T]):
+    user_prompt: str
+    output_schema: Type[T]
+    llm_config: Optional[_LLMModelConfig] = None
+
+
+models_stub.LLMResponse = LLMResponse
+models_stub.StructuredLLMRequest = StructuredLLMRequest
+sys.modules["agent_management.models"] = models_stub
+agent_root.models = models_stub
+sys.modules["api.agent_management.models"] = models_stub
+
+
+llm_stub = types.ModuleType("agent_management.llm_service")
+
+class _DummyProvider:
+    def generate(self, request: Any) -> LLMResponse:
+        return LLMResponse(content="ok", model="test", usage={})
+
+    def generate_structured(self, request: Any) -> Dict[str, Any]:
+        return {"key": "value"}
+
+
+class LLMService:
+    def __init__(self, config: _LLMModelConfig):
+        self.config = config
+        self._provider = _DummyProvider()
+
+    def generate(self, request: "LLMRequest") -> LLMResponse:
+        return self._provider.generate(request)
+
+    def generate_structured(self, request: Any) -> Dict[str, Any]:
+        return self._provider.generate_structured(request)
+
+
+class LLMRequest(BaseModel):
+    user_prompt: str
+
+
+llm_stub.LLMService = LLMService
+llm_stub.LLMRequest = LLMRequest
+llm_stub.LLMResponse = LLMResponse
+sys.modules["agent_management.llm_service"] = llm_stub
+agent_root.llm_service = llm_stub
+sys.modules["api.agent_management.llm_service"] = llm_stub
+
+# Stub heavy optional dependencies before loading router module
+chem_mod = types.ModuleType("rdkit.Chem")
+chem_mod.Fragments = object
+chem_mod.Descriptors = object
+chem_mod.AllChem = object
+rdkit_mod = types.ModuleType("rdkit")
+rdkit_mod.Chem = chem_mod
+sys.modules["rdkit"] = rdkit_mod
+sys.modules["rdkit.Chem"] = chem_mod
+
+openai_mod = types.ModuleType("openai")
+openai_mod.OpenAI = object
+types_mod = types.ModuleType("openai.types")
+chat_mod = types.ModuleType("openai.types.chat")
+chat_completion_mod = types.ModuleType("openai.types.chat.chat_completion")
+setattr(types_mod, "Completion", object)
+setattr(chat_mod, "ChatCompletion", object)
+setattr(chat_mod, "ChatCompletionMessage", object)
+setattr(chat_mod, "ChatCompletionMessageParam", dict)
+setattr(chat_completion_mod, "Choice", object)
+sys.modules["openai"] = openai_mod
+sys.modules["openai.types"] = types_mod
+sys.modules["openai.types.chat"] = chat_mod
+sys.modules["openai.types.chat.chat_completion"] = chat_completion_mod
+
+import importlib.util
+from pathlib import Path
+
+_routes_path = Path(__file__).resolve().parents[1] / "routers" / "rcsb" / "routes.py"
+spec = importlib.util.spec_from_file_location("rcsb_routes", _routes_path)
+rcsb_module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(rcsb_module)
+rcsb_router = rcsb_module.router
+
 # Create a minimal FastAPI app for unit tests to avoid importing the full server
 app = FastAPI()
+app.include_router(rcsb_router)
 
 
 @app.post("/prompt/")

--- a/api/tests/integration/test_rcsb_new.py
+++ b/api/tests/integration/test_rcsb_new.py
@@ -1,0 +1,50 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from agent_management.agents.rcsb_agent import RCSBAgent
+
+
+@pytest.mark.integration
+def test_pairwise_alignment_endpoint(test_client: TestClient):
+    original = RCSBAgent.fetch_pairwise_alignment
+    def fake(self, id_one: str, id_two: str) -> dict:
+        assert id_one == "1AAA"
+        assert id_two == "2BBB"
+        return {"score": 42}
+    RCSBAgent.fetch_pairwise_alignment = fake
+    try:
+        resp = test_client.post("/rcsb/align/", json={"identifier1": "1AAA", "identifier2": "2BBB"})
+        assert resp.status_code == 200
+        assert resp.json()["metadata"]["score"] == 42
+    finally:
+        RCSBAgent.fetch_pairwise_alignment = original
+
+
+@pytest.mark.integration
+def test_group_entries_endpoint(test_client: TestClient):
+    original = RCSBAgent.fetch_group_entries
+    def fake(self, group_id: str) -> dict:
+        assert group_id == "G123"
+        return {"entries": ["1AAA", "2BBB"]}
+    RCSBAgent.fetch_group_entries = fake
+    try:
+        resp = test_client.get("/rcsb/group/G123")
+        assert resp.status_code == 200
+        assert resp.json()["metadata"]["entries"] == ["1AAA", "2BBB"]
+    finally:
+        RCSBAgent.fetch_group_entries = original
+
+
+@pytest.mark.integration
+def test_feature_annotations_endpoint(test_client: TestClient):
+    original = RCSBAgent.fetch_feature_annotations
+    def fake(self, identifier: str) -> dict:
+        assert identifier == "1AAA"
+        return {"features": []}
+    RCSBAgent.fetch_feature_annotations = fake
+    try:
+        resp = test_client.get("/rcsb/feature-annotations/1AAA")
+        assert resp.status_code == 200
+        assert resp.json()["annotations"]["features"] == []
+    finally:
+        RCSBAgent.fetch_feature_annotations = original


### PR DESCRIPTION
## Summary
- add pairwise alignment, group entry and feature annotation methods to `RCSBAgent`
- expose `/rcsb/align/`, `/rcsb/group/{group_id}` and `/rcsb/feature-annotations/{identifier}` routes
- extend test app to include RCSB router
- provide integration tests for the new endpoints with network stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e793815008321936678240d9f814d