### PR TITLE
Add SceneSpec model and LLM translator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,10 @@ Following the July 18 2025 RCSB agent expansion [oai_citation:7‡GitHub](https:
 * **Scene template library:** Implemented parameterized helpers for overview, binding site and mutation focus scenes. Added a lightweight prompt translator and unit tests covering the mutation helper and translator logic.
 
 These steps lay the foundation for subsequent Mol* integration, job orchestration and XR/VR export features [oai_citation:8‡GitHub](https://github.com/jakekinchen/moleculens-server/blob/c032a23995e32c9aafb72cd96d2c894e789b0bb8/AGENTS.md#L32-L65).
+
+### pymol_prompt_parser
+* Stateless; uses OpenAI function calling (`build_scene_request`) to convert free-form English into a `SceneSpec` JSON payload.
+
+### pymol_command_builder
+* Accepts `SceneSpec`, dispatches to template helpers (`overview_scene`, `binding_site_scene`, `mutation_scene`).
+* Raises `SceneValidationError` (Pydantic) on invalid specs.

--- a/api/agent_management/scene_spec.py
+++ b/api/agent_management/scene_spec.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Literal, Optional, List, Dict, Any
+from pydantic import BaseModel, Field
+
+
+class SceneSpec(BaseModel):
+    """Validated payload for every PyMOL request."""
+
+    op: Literal["overview", "binding_site", "mutation", "raw"]
+    structure_id: str
+    selection: Optional[str] = Field(
+        default=None,
+        description="PyMOL atom-selection targeting a subset of atoms.",
+    )
+    opts: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Operation-specific keyword arguments.",
+    )
+    raw_cmds: Optional[List[str]] = Field(
+        default=None,
+        description="Explicit PyMOL commands when op == 'raw'.",
+    )

--- a/api/tests/unit/test_pymol_translator.py
+++ b/api/tests/unit/test_pymol_translator.py
@@ -1,24 +1,55 @@
 import os
 import sys
 import importlib.util
+import types
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT))
 
-spec_t = importlib.util.spec_from_file_location(
-    "api.agent_management.pymol_translator", ROOT / "api" / "agent_management" / "pymol_translator.py"
-)
-module_t = importlib.util.module_from_spec(spec_t)
-assert spec_t and spec_t.loader
-spec_t.loader.exec_module(module_t)
-sys.modules["api.agent_management.pymol_translator"] = module_t
-translate = module_t.translate
+
+def _load_scene_spec() -> type:
+    spec_s = importlib.util.spec_from_file_location(
+        "api.agent_management.scene_spec",
+        ROOT / "api" / "agent_management" / "scene_spec.py",
+    )
+    module = importlib.util.module_from_spec(spec_s)
+    assert spec_s and spec_s.loader
+    spec_s.loader.exec_module(module)
+    return module.SceneSpec
 
 
-def test_translate_mutation_prompt():
-    cmd_list = translate("mutation 1ubq resi 50 and chain A")
-    assert isinstance(cmd_list, list)
-    assert cmd_list[0].startswith("fetch 1ubq")
-    # The translator should have used the mutation template (looks for colour magenta)
-    assert any("magenta" in c for c in cmd_list)
+def _load_translator(monkeypatch: any) -> any:
+    pkg = types.ModuleType("api.agent_management")
+    pkg.__path__ = [str(ROOT / "api" / "agent_management")]
+    api_pkg = types.ModuleType("api")
+    api_pkg.agent_management = pkg
+    monkeypatch.setitem(sys.modules, "api", api_pkg)
+    monkeypatch.setitem(sys.modules, "api.agent_management", pkg)
+
+    spec_t = importlib.util.spec_from_file_location(
+        "api.agent_management.pymol_translator",
+        ROOT / "api" / "agent_management" / "pymol_translator.py",
+    )
+    module_t = importlib.util.module_from_spec(spec_t)
+    assert spec_t and spec_t.loader
+    spec_t.loader.exec_module(module_t)
+    monkeypatch.setitem(sys.modules, "api.agent_management.pymol_translator", module_t)
+    return module_t
+
+
+def test_translate_with_stub(monkeypatch):
+    SceneSpec = _load_scene_spec()
+    module_t = _load_translator(monkeypatch)
+    translate = module_t.translate
+
+    stub_spec = SceneSpec(
+        op="mutation",
+        structure_id="1ubq",
+        selection="resi 50 and chain A",
+    )
+    monkeypatch.setattr(module_t, "_spec_from_prompt", lambda _: stub_spec)
+
+    cmds = translate("any text here")
+    assert cmds[0].startswith("fetch 1ubq")
+    assert any("magenta" in c for c in cmds)

--- a/api/tests/unit/test_scene_spec.py
+++ b/api/tests/unit/test_scene_spec.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))
+
+spec = importlib.util.spec_from_file_location(
+    "api.agent_management.scene_spec",
+    ROOT / "api" / "agent_management" / "scene_spec.py",
+)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+SceneSpec = module.SceneSpec
+
+
+def test_scene_spec_validation():
+    spec = SceneSpec(
+        op="mutation",
+        structure_id="1ubq",
+        selection="resi 50 and chain A",
+        opts={"original_residue": "F"},
+    )
+    assert spec.op == "mutation"
+    assert spec.selection.startswith("resi")


### PR DESCRIPTION
## Summary
- introduce `SceneSpec` data model for PyMOL requests
- rewrite `pymol_translator` to use OpenAI function-calling
- document new prompt parser and command builder
- add unit tests for `SceneSpec` and new translator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eaed31b30832196710f2e358f7cc4