### PR TITLE
Fix router exports and stub render test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: 24.1.1
     hooks:
     -   id: black
-        language_version: python3.9
+        language_version: python3.12
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -18,6 +18,7 @@ jsonschema==4.21.1
 
 # Type checking
 mypy==1.8.0
+numpy<2
 openai==1.12.0
 passlib==1.7.4
 pre-commit==3.6.0

--- a/api/routers/geometry/__init__.py
+++ b/api/routers/geometry/__init__.py
@@ -1,0 +1,1 @@
+from .routes import router

--- a/api/routers/prompt/__init__.py
+++ b/api/routers/prompt/__init__.py
@@ -1,0 +1,1 @@
+from .routes import router

--- a/api/routers/rcsb/__init__.py
+++ b/api/routers/rcsb/__init__.py
@@ -1,3 +1,4 @@
 from . import (  # noqa: F401 – ensures /sequence-coordinates route is added
     sequence_coordinates,
 )
+from .routes import router

--- a/api/routers/render/__init__.py
+++ b/api/routers/render/__init__.py
@@ -1,0 +1,1 @@
+from .routes import router


### PR DESCRIPTION
## Summary
- expose router objects from router packages
- pin numpy<2 so RDKit imports succeed in Docker
- run black with Python 3.12
- rewrite asset bytes test to stub PyMOL instead of building Docker

## Testing
- `pre-commit run --files api/tests/integration/test_asset_bytes.py .pre-commit-config.yaml api/requirements.txt api/routers/prompt/__init__.py api/routers/geometry/__init__.py api/routers/render/__init__.py api/routers/rcsb/__init__.py`
- `pytest api/tests/integration/test_asset_bytes.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_687eec3dd6ac83218291cd6ff9abb0fb