### PR TITLE
Refactor translator imports and simplify router

### DIFF
--- a/api/agent_management/pymol_translator.py
+++ b/api/agent_management/pymol_translator.py
@@ -1,50 +1,22 @@
-from __future__ import annotations
-
-import importlib.util
 import json
-import os
-import sys
 from typing import Any, List
 
 try:
     from ..utils.openai_client import get_client
-except ImportError:
-    # Fallback for direct module loading in tests
+except ImportError:  # pragma: no cover - fallback when package context missing
+    import importlib.util
     import os
-    import sys
 
-    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-    from utils.openai_client import get_client
-
-
-# Additional fallback: create client directly if get_client fails
-def _get_openai_client():
-    """Get OpenAI client with fallback."""
-    try:
-        return get_client()
-    except Exception:
-        # Direct import and creation as fallback
-        import os
-
-        from openai import OpenAI
-
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            raise ValueError("OpenAI API key is required")
-        return OpenAI(api_key=api_key)
-
-
-# Import pymol_templates directly
-templates_path = os.path.join(os.path.dirname(__file__), "pymol_templates.py")
-spec = importlib.util.spec_from_file_location("pymol_templates", templates_path)
-pymol_templates = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(pymol_templates)
-
-# Import scene_spec directly
-scene_spec_path = os.path.join(os.path.dirname(__file__), "scene_spec.py")
-spec = importlib.util.spec_from_file_location("scene_spec", scene_spec_path)
-scene_spec = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(scene_spec)
+    utils_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../utils/openai_client.py")
+    )
+    spec = importlib.util.spec_from_file_location("openai_client", utils_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    get_client = module.get_client
+from . import pymol_templates
+from .scene_spec import SceneSpec
 
 _DISPATCH = {
     "overview": pymol_templates.overview_scene,
@@ -54,18 +26,18 @@ _DISPATCH = {
 }
 
 
-def _spec_from_prompt(prompt: str) -> scene_spec.SceneSpec:
+def _spec_from_prompt(prompt: str) -> SceneSpec:
     """Convert free-form prompt to validated SceneSpec via OpenAI function calling."""
     print("\n" + "=" * 80)
     print("TRANSLATING PROMPT:")
     print(prompt)
     print("-" * 80)
 
-    client = _get_openai_client()
+    client = get_client()
     functions = [
         {
             "name": "build_scene_request",
-            "parameters": scene_spec.SceneSpec.model_json_schema(),
+            "parameters": SceneSpec.model_json_schema(),
             "description": "Return a SceneSpec describing the requested PyMOL operation.",
         }
     ]
@@ -84,7 +56,7 @@ def _spec_from_prompt(prompt: str) -> scene_spec.SceneSpec:
         data = json.loads(completion.choices[0].message.function_call.arguments)
         print("\nGenerated spec:")
         print(json.dumps(data, indent=2))
-        return scene_spec.SceneSpec(**data)
+        return SceneSpec(**data)
 
     except Exception as e:
         print(f"\nError in LLM translation: {str(e)}")

--- a/api/tests/test_imports.py
+++ b/api/tests/test_imports.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 import sys
+from pathlib import Path
 
 
 def test_imports():
@@ -9,10 +10,10 @@ def test_imports():
     print("Directory contents:", os.listdir())
 
     try:
-        # Try to load the module directly
-        spec = importlib.util.spec_from_file_location(
-            "routes", "/app/api/routers/render/routes.py"
+        routes_path = (
+            Path(__file__).resolve().parents[1] / "routers" / "render" / "routes.py"
         )
+        spec = importlib.util.spec_from_file_location("routes", routes_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 


### PR DESCRIPTION
## Summary
- clean up `pymol_translator` imports and remove heavy fallbacks
- simplify render router imports and eval context
- fix import-path test to use repo-relative path
- run black formatting on touched files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fd5eddefc832187b5c63a04bac5aa