### PR TITLE
Add graphic spec schema

### DIFF
--- a/api/agent_management/pymol_translator.py
+++ b/api/agent_management/pymol_translator.py
@@ -74,7 +74,12 @@ def _spec_from_prompt(prompt: str) -> SceneSpec:
             op="raw", structure_id="1ubq", raw_cmds=["cmd.fragment('ala')"]
         )
 
+
+def translate(prompt: str) -> List[str]:
+    """Translate a natural-language prompt into PyMOL commands."""
+    spec = _spec_from_prompt(prompt)
     logger.info(f"Operation type: {spec.op}")
+
     if spec.op == "raw":
         commands = spec.raw_cmds or []
     else:

--- a/schema/graphic.schema.json
+++ b/schema/graphic.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Molecule Graphic Specification",
+  "type": "object",
+  "required": ["meta", "canvas", "cells"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["title", "version"],
+      "properties": {
+        "title": {"type": "string"},
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"}
+      },
+      "additionalProperties": false
+    },
+    "canvas": {
+      "type": "object",
+      "required": ["w", "h"],
+      "properties": {
+        "w": {"type": "integer"},
+        "h": {"type": "integer"},
+        "dpi": {"type": "integer"}
+      },
+      "additionalProperties": false
+    },
+    "cells": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "bbox"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z0-9_]+$"},
+          "type": {
+            "type": "string",
+            "enum": ["TEXT", "DIAGRAM", "IMAGE_GEN", "COMPUTE", "GROUP"]
+          },
+          "bbox": {
+            "type": "object",
+            "required": ["x", "y", "w", "h"],
+            "properties": {
+              "x": {"type": "number"},
+              "y": {"type": "number"},
+              "w": {"type": "number"},
+              "h": {"type": "number"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- create `schema/graphic.schema.json` as described in the infographic refactor plan
- fix `pymol_translator` to provide a `translate` helper used in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff58d2dd883219544ea20aa148c80