### PR TITLE
Fix pre-commit hooks paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,18 +13,18 @@ repos:
     hooks:
     -   id: black
         name: black
-        entry: /Users/jakekinchen/.pyenv/versions/3.9.6/bin/black
+        entry: black
         language: system
         types: [python]
 
     -   id: isort
         name: isort
-        entry: /opt/homebrew/Caskroom/miniforge/base/bin/isort --profile black
+        entry: isort --profile black
         language: system
         types: [python]
 
     -   id: flake8
         name: flake8
-        entry: /opt/homebrew/Caskroom/miniforge/base/bin/flake8
+        entry: flake8
         language: system
         types: [python]


### PR DESCRIPTION
## Summary
- update `.pre-commit-config.yaml` to call `black`, `isort` and `flake8` from the active environment

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api.agent_management.agents.pubchem_agent')*

------
https://chatgpt.com/codex/tasks/task_e_6880da9ead008321a6e4fb11f89b5859