### PR TITLE
fix: recover from stale cached results

### DIFF
--- a/src/moleculens/api/electrostatics_routes.py
+++ b/src/moleculens/api/electrostatics_routes.py
@@ -19,12 +19,32 @@ from moleculens.api.schemas import (
     UnitsResponse,
 )
 from moleculens.core import get_logger, settings
-from moleculens.db import JobQueue, JobStatus
+from moleculens.db import Job, JobQueue, JobStatus
 
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/v1/electrostatics", tags=["electrostatics"])
 job_queue = JobQueue()
+
+
+def _missing_electrostatics_result_error(cache_key: str) -> str:
+    return f"Cached result missing for cache key {cache_key[:12]}"
+
+
+def _load_or_invalidate_electrostatics_result(job: Job) -> ElectrostaticsResult | None:
+    """Load a completed electrostatics result or invalidate the stale cache entry."""
+    result = _load_electrostatics_result(job.cache_key, job.result_meta)
+    if result is not None:
+        return result
+
+    error_message = _missing_electrostatics_result_error(job.cache_key)
+    logger.warning(
+        "Completed electrostatics job missing result payload; invalidating cache",
+        job_id=job.id[:12],
+        cache_key=job.cache_key[:12],
+    )
+    job_queue.invalidate_cache_key(job.cache_key, error_message)
+    return None
 
 
 def _compute_electrostatics_cache_key(
@@ -140,7 +160,64 @@ async def compute_electrostatics(request: ElectrostaticsRequest) -> Electrostati
 
     # If cached or done, load result
     if job.status == JobStatus.DONE:
-        response.result = _load_electrostatics_result(cache_key, job.result_meta)
+        result = _load_or_invalidate_electrostatics_result(job)
+        if result is None:
+            retry_job_id, retry_is_cached = job_queue.submit_job(
+                sdf_content=request.sdf_content,
+                method=request.method,
+                basis="electrostatics",
+                grid_spacing=request.surface.grid_spacing,
+                isovalue=0.0,
+                orbitals=["electrostatics"],
+                inchi_key=request.inchi_key,
+                geometry_hash=cache_key,
+            )
+            retry_job = job_queue.get_job(retry_job_id)
+            if retry_job is None:
+                raise HTTPException(status_code=500, detail="Job not found after cache recovery")
+
+            job_queue._update_job_params(
+                retry_job_id,
+                {
+                    "job_type": "electrostatics",
+                    "sdf_content": request.sdf_content,
+                    "charge": request.charge,
+                    "multiplicity": request.multiplicity,
+                    "method": request.method,
+                    "surface": surface_params,
+                    "potential": potential_params,
+                },
+            )
+
+            response = ElectrostaticsJobResponse(
+                cached=retry_is_cached,
+                jobId=retry_job.id,
+                status=retry_job.status.value,  # type: ignore[arg-type]
+                cacheKey=retry_job.cache_key,
+                createdAt=retry_job.created_at.isoformat() if retry_job.created_at else None,
+            )
+
+            if retry_job.status == JobStatus.DONE:
+                retry_result = _load_or_invalidate_electrostatics_result(retry_job)
+                if retry_result is None:
+                    return ElectrostaticsJobResponse(
+                        cached=False,
+                        jobId=retry_job.id,
+                        status="error",
+                        cacheKey=retry_job.cache_key,
+                        createdAt=retry_job.created_at.isoformat()
+                        if retry_job.created_at
+                        else None,
+                        computeTimeMs=retry_job.compute_time_ms,
+                        errorMessage=_missing_electrostatics_result_error(retry_job.cache_key),
+                    )
+
+                response.result = retry_result
+                response.compute_time_ms = retry_job.compute_time_ms
+
+            return response
+
+        response.result = result
         response.compute_time_ms = job.compute_time_ms
 
     return response
@@ -163,7 +240,19 @@ async def get_electrostatics_job(job_id: str) -> ElectrostaticsJobResponse:
     )
 
     if job.status == JobStatus.DONE:
-        response.result = _load_electrostatics_result(job.cache_key, job.result_meta)
+        result = _load_or_invalidate_electrostatics_result(job)
+        if result is None:
+            return ElectrostaticsJobResponse(
+                cached=False,
+                jobId=job.id,
+                status="error",
+                cacheKey=job.cache_key,
+                createdAt=job.created_at.isoformat() if job.created_at else None,
+                computeTimeMs=job.compute_time_ms,
+                errorMessage=_missing_electrostatics_result_error(job.cache_key),
+            )
+
+        response.result = result
     elif job.status == JobStatus.ERROR:
         response.error_message = job.error_message
 

--- a/src/moleculens/api/routes.py
+++ b/src/moleculens/api/routes.py
@@ -16,12 +16,32 @@ from moleculens.api.schemas import (
     OrbitalResponse,
 )
 from moleculens.core import get_logger, settings
-from moleculens.db import JobQueue, JobStatus, get_db_engine
+from moleculens.db import Job, JobQueue, JobStatus, get_db_engine
 
 logger = get_logger(__name__)
 
 router = APIRouter()
 job_queue = JobQueue()
+
+
+def _missing_result_error(cache_key: str) -> str:
+    return f"Cached result missing for cache key {cache_key[:12]}"
+
+
+def _load_or_invalidate_done_result(job: Job) -> ComputeResult | None:
+    """Load a completed result or invalidate the stale cache entry."""
+    result = _load_result(job.cache_key, job.result_meta)
+    if result is not None:
+        return result
+
+    error_message = _missing_result_error(job.cache_key)
+    logger.warning(
+        "Completed job missing result payload; invalidating cache",
+        job_id=job.id[:12],
+        cache_key=job.cache_key[:12],
+    )
+    job_queue.invalidate_cache_key(job.cache_key, error_message)
+    return None
 
 
 @router.get("/health", response_model=HealthResponse)
@@ -90,7 +110,50 @@ async def compute_orbitals(request: ComputeRequest) -> JobResponse:
 
     # If cached or done, load result
     if job.status == JobStatus.DONE:
-        response.result = _load_result(job.cache_key, job.result_meta)
+        result = _load_or_invalidate_done_result(job)
+        if result is None:
+            retry_job_id, retry_is_cached = job_queue.submit_job(
+                sdf_content=request.sdf_content,
+                method=request.method,
+                basis=request.basis,
+                grid_spacing=request.grid_spacing,
+                isovalue=request.isovalue,
+                orbitals=request.orbitals,
+                inchi_key=request.inchi_key,
+            )
+            retry_job = job_queue.get_job(retry_job_id)
+            if retry_job is None:
+                raise HTTPException(status_code=500, detail="Job not found after cache recovery")
+
+            response = JobResponse(
+                cached=retry_is_cached,
+                jobId=retry_job.id,
+                status=retry_job.status.value,  # type: ignore[arg-type]
+                cacheKey=retry_job.cache_key,
+                createdAt=retry_job.created_at.isoformat() if retry_job.created_at else None,
+            )
+
+            if retry_job.status == JobStatus.DONE:
+                retry_result = _load_or_invalidate_done_result(retry_job)
+                if retry_result is None:
+                    return JobResponse(
+                        cached=False,
+                        jobId=retry_job.id,
+                        status="error",
+                        cacheKey=retry_job.cache_key,
+                        createdAt=retry_job.created_at.isoformat()
+                        if retry_job.created_at
+                        else None,
+                        computeTimeMs=retry_job.compute_time_ms,
+                        errorMessage=_missing_result_error(retry_job.cache_key),
+                    )
+
+                response.result = retry_result
+                response.compute_time_ms = retry_job.compute_time_ms
+
+            return response
+
+        response.result = result
         response.compute_time_ms = job.compute_time_ms
 
     return response
@@ -113,7 +176,19 @@ async def get_job_status(job_id: str) -> JobResponse:
     )
 
     if job.status == JobStatus.DONE:
-        response.result = _load_result(job.cache_key, job.result_meta)
+        result = _load_or_invalidate_done_result(job)
+        if result is None:
+            return JobResponse(
+                cached=False,
+                jobId=job.id,
+                status="error",
+                cacheKey=job.cache_key,
+                createdAt=job.created_at.isoformat() if job.created_at else None,
+                computeTimeMs=job.compute_time_ms,
+                errorMessage=_missing_result_error(job.cache_key),
+            )
+
+        response.result = result
     elif job.status == JobStatus.ERROR:
         response.error_message = job.error_message
 

--- a/src/moleculens/db/queue.py
+++ b/src/moleculens/db/queue.py
@@ -119,6 +119,89 @@ class JobQueue:
         """
         self.cache_dir = cache_dir or settings.molecule_cache_dir
 
+    def _required_artifact_paths(self, artifact_paths: list[str]) -> list[str]:
+        """Return the minimum artifact set required for a cache entry to be reusable."""
+        result_manifests = [path for path in artifact_paths if path.endswith("result.json")]
+        return result_manifests or artifact_paths
+
+    def _cache_artifacts_exist(self, cache_key: str, artifact_paths: list[str]) -> bool:
+        """Check whether the required cache artifacts still exist on disk."""
+        required_paths = self._required_artifact_paths(artifact_paths)
+        if not required_paths:
+            return False
+
+        cache_root = self.cache_dir / cache_key
+        return all((cache_root / path).exists() for path in required_paths)
+
+    def _invalidate_cache_key(self, session: Session, cache_key: str, error_message: str) -> None:
+        """Invalidate a cache entry and mark stale completed jobs as failed."""
+        cache_entry = session.get(CacheEntry, cache_key)
+        if cache_entry is not None:
+            session.delete(cache_entry)
+
+        stale_jobs = (
+            session.execute(
+                select(Job).where(Job.cache_key == cache_key).where(Job.status == JobStatus.DONE)
+            )
+            .scalars()
+            .all()
+        )
+
+        invalidated_jobs = 0
+        for stale_job in stale_jobs:
+            stale_job.status = JobStatus.ERROR
+            stale_job.error_message = error_message
+            stale_job.completed_at = datetime.now(UTC)
+            invalidated_jobs += 1
+
+        logger.warning(
+            "Invalidated stale cache entry",
+            cache_key=cache_key[:12],
+            invalidated_jobs=invalidated_jobs,
+            reason=error_message[:200],
+        )
+
+    def invalidate_cache_key(self, cache_key: str, error_message: str) -> None:
+        """Public wrapper for invalidating a corrupt cache entry."""
+        with db_session() as session:
+            self._invalidate_cache_key(session, cache_key, error_message)
+
+    def _reuse_cached_job_if_valid(
+        self, session: Session, cache_key: str
+    ) -> tuple[str, bool] | None:
+        """Return a reusable cached job if its artifacts still exist."""
+        cache_entry = session.get(CacheEntry, cache_key)
+        if cache_entry is None:
+            return None
+
+        cache_error = f"Cached result missing for cache key {cache_key[:12]}"
+        if not self._cache_artifacts_exist(cache_key, cache_entry.artifact_paths):
+            self._invalidate_cache_key(session, cache_key, cache_error)
+            return None
+
+        cache_entry.hit_count += 1
+        cache_entry.last_accessed_at = datetime.now(UTC)
+
+        existing_job = session.execute(
+            select(Job)
+            .where(Job.cache_key == cache_key)
+            .where(Job.status == JobStatus.DONE)
+            .limit(1)
+        ).scalar_one_or_none()
+
+        if existing_job is None:
+            return None
+
+        if existing_job.result_meta is None:
+            existing_job.result_meta = cache_entry.result_meta
+
+        logger.info(
+            "Returning cached result",
+            cache_key=cache_key[:12],
+            job_id=existing_job.id[:12],
+        )
+        return existing_job.id, True
+
     def submit_job(
         self,
         sdf_content: str,
@@ -164,28 +247,9 @@ class JobQueue:
         )
 
         with db_session() as session:
-            # Check for cached result
-            cache_entry = session.get(CacheEntry, cache_key)
-            if cache_entry is not None:
-                # Update hit count
-                cache_entry.hit_count += 1
-                cache_entry.last_accessed_at = datetime.now(UTC)
-
-                # Find or create job pointing to cache
-                existing_job = session.execute(
-                    select(Job)
-                    .where(Job.cache_key == cache_key)
-                    .where(Job.status == JobStatus.DONE)
-                    .limit(1)
-                ).scalar_one_or_none()
-
-                if existing_job:
-                    logger.info(
-                        "Returning cached result",
-                        cache_key=cache_key[:12],
-                        job_id=existing_job.id[:12],
-                    )
-                    return existing_job.id, True
+            cached_job = self._reuse_cached_job_if_valid(session, cache_key)
+            if cached_job is not None:
+                return cached_job
 
             # Check for pending/running job with same cache key
             pending_job = session.execute(
@@ -239,27 +303,9 @@ class JobQueue:
             Tuple of (job_id, is_cached)
         """
         with db_session() as session:
-            # Check for cached result
-            cache_entry = session.get(CacheEntry, cache_key)
-            if cache_entry is not None:
-                # Update hit count
-                cache_entry.hit_count += 1
-                cache_entry.last_accessed_at = datetime.now(UTC)
-
-                existing_job = session.execute(
-                    select(Job)
-                    .where(Job.cache_key == cache_key)
-                    .where(Job.status == JobStatus.DONE)
-                    .limit(1)
-                ).scalar_one_or_none()
-
-                if existing_job:
-                    logger.info(
-                        "Returning cached result",
-                        cache_key=cache_key[:12],
-                        job_id=existing_job.id[:12],
-                    )
-                    return existing_job.id, True
+            cached_job = self._reuse_cached_job_if_valid(session, cache_key)
+            if cached_job is not None:
+                return cached_job
 
             # Check for pending/running job with same cache key
             pending_job = session.execute(

--- a/tests/unit/test_job_queue.py
+++ b/tests/unit/test_job_queue.py
@@ -1,0 +1,161 @@
+"""Unit tests for stale cache invalidation and job recovery."""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from moleculens.api import routes
+from moleculens.db import queue as queue_module
+from moleculens.db.models import Base, CacheEntry, Job, JobStatus
+from moleculens.db.queue import JobQueue
+
+
+@pytest.fixture
+def isolated_job_queue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> JobQueue:
+    """Provide an isolated SQLite-backed job queue and cache directory."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'queue.db'}")
+    monkeypatch.setattr(queue_module, "_engine", engine)
+    monkeypatch.setattr(queue_module, "_session_factory", sessionmaker(bind=engine))
+    monkeypatch.setattr(queue_module.settings, "molecule_cache_dir", cache_dir)
+
+    Base.metadata.create_all(engine)
+
+    routes.job_queue = JobQueue(cache_dir=cache_dir)
+    return JobQueue(cache_dir=cache_dir)
+
+
+def _seed_done_job(
+    job_queue: JobQueue,
+    *,
+    geometry_hash: str,
+    result_meta: dict | None,
+    artifact_paths: list[str],
+) -> tuple[str, str]:
+    """Create a completed job + cache entry for the given cache key."""
+    job_id, is_cached = job_queue.submit_job(
+        sdf_content="not-used",
+        method="scf",
+        basis="sto-3g",
+        grid_spacing=0.25,
+        isovalue=0.05,
+        orbitals=["homo"],
+        geometry_hash=geometry_hash,
+    )
+    assert is_cached is False
+
+    job = job_queue.get_job(job_id)
+    assert job is not None
+    cache_key = job.cache_key
+
+    with queue_module.db_session() as session:
+        seeded_job = session.get(Job, job_id)
+        assert seeded_job is not None
+        seeded_job.status = JobStatus.DONE
+        seeded_job.result_meta = result_meta
+        seeded_job.compute_time_ms = 123.0
+
+        session.add(
+            CacheEntry(
+                cache_key=cache_key,
+                params_hash=cache_key,
+                result_meta={"method": "scf", "basis": "sto-3g"},
+                artifact_paths=artifact_paths,
+            )
+        )
+
+    return job_id, cache_key
+
+
+def test_submit_job_reuses_valid_cache_and_restores_missing_result_meta(
+    isolated_job_queue: JobQueue,
+) -> None:
+    job_id, cache_key = _seed_done_job(
+        isolated_job_queue,
+        geometry_hash="geom-valid",
+        result_meta=None,
+        artifact_paths=["result.json"],
+    )
+
+    cache_root = isolated_job_queue.cache_dir / cache_key
+    cache_root.mkdir()
+    (cache_root / "result.json").write_text('{"orbitals": {}, "meta": {"method": "scf"}}')
+
+    reused_job_id, is_cached = isolated_job_queue.submit_job(
+        sdf_content="not-used",
+        method="scf",
+        basis="sto-3g",
+        grid_spacing=0.25,
+        isovalue=0.05,
+        orbitals=["homo"],
+        geometry_hash="geom-valid",
+    )
+
+    assert is_cached is True
+    assert reused_job_id == job_id
+
+    reused_job = isolated_job_queue.get_job(job_id)
+    assert reused_job is not None
+    assert reused_job.result_meta == {"method": "scf", "basis": "sto-3g"}
+
+
+def test_submit_job_invalidates_stale_cache_and_requeues(
+    isolated_job_queue: JobQueue,
+) -> None:
+    stale_job_id, cache_key = _seed_done_job(
+        isolated_job_queue,
+        geometry_hash="geom-stale",
+        result_meta={"method": "scf", "basis": "sto-3g"},
+        artifact_paths=["result.json"],
+    )
+
+    new_job_id, is_cached = isolated_job_queue.submit_job(
+        sdf_content="not-used",
+        method="scf",
+        basis="sto-3g",
+        grid_spacing=0.25,
+        isovalue=0.05,
+        orbitals=["homo"],
+        geometry_hash="geom-stale",
+    )
+
+    assert is_cached is False
+    assert new_job_id != stale_job_id
+
+    stale_job = isolated_job_queue.get_job(stale_job_id)
+    assert stale_job is not None
+    assert stale_job.status == JobStatus.ERROR
+    assert stale_job.error_message == f"Cached result missing for cache key {cache_key[:12]}"
+
+    new_job = isolated_job_queue.get_job(new_job_id)
+    assert new_job is not None
+    assert new_job.status == JobStatus.PENDING
+
+    assert isolated_job_queue.get_cache_entry(cache_key) is None
+
+
+@pytest.mark.asyncio
+async def test_get_job_status_reports_error_for_done_job_with_missing_result(
+    isolated_job_queue: JobQueue,
+) -> None:
+    stale_job_id, cache_key = _seed_done_job(
+        isolated_job_queue,
+        geometry_hash="geom-poll-stale",
+        result_meta={"method": "scf", "basis": "sto-3g"},
+        artifact_paths=["result.json"],
+    )
+
+    response = await routes.get_job_status(stale_job_id)
+
+    assert response.status == "error"
+    assert response.error_message == f"Cached result missing for cache key {cache_key[:12]}"
+    assert response.result is None
+
+    stale_job = isolated_job_queue.get_job(stale_job_id)
+    assert stale_job is not None
+    assert stale_job.status == JobStatus.ERROR
+    assert isolated_job_queue.get_cache_entry(cache_key) is None


### PR DESCRIPTION
## Summary
- invalidate cached DONE jobs when required result artifacts are missing
- return an explicit error instead of `done` with `null` result payloads
- retry compute submissions once after stale-cache invalidation and cover the queue behavior with unit tests

## Validation
- `uv run ruff check src/moleculens/db/queue.py src/moleculens/api/routes.py src/moleculens/api/electrostatics_routes.py tests/unit/test_job_queue.py`
- `uv run ruff format --check src/moleculens/db/queue.py src/moleculens/api/routes.py src/moleculens/api/electrostatics_routes.py tests/unit/test_job_queue.py`
- `PYTHONPATH=src uv run --extra dev --python 3.11 python -m pytest tests/unit/test_job_queue.py`